### PR TITLE
initial cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,5 @@
+cmake_minimum_required(VERSION 3.0)
+
+project(adj VERSION 1.0.0 LANGUAGES Fortran)
+
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+add_library(adj STATIC
+   bioptimod_memory.f90 fm34.f90 SLAE.f90 adj_new.f90
+)
+
+add_executable(adj_exe
+   main_adj.f90
+)
+set_property(TARGET adj_exe PROPERTY OUTPUT_NAME adj)
+
+target_link_libraries(adj_exe PRIVATE adj)
+


### PR DESCRIPTION
added basic cmake support for building static adj library and executable, in order to facilitate integration with FABMized multispectral BFM